### PR TITLE
Fix build_and_setup_everything_bazel_manually.sh VMware setup

### DIFF
--- a/build_and_setup_everything_bazel_manually.sh
+++ b/build_and_setup_everything_bazel_manually.sh
@@ -6,9 +6,9 @@
 
 ./build_forklift_bazel.sh
 
-./vmware/setup.sh
-
 ./deploy_local_forklift_bazel.sh
+
+./vmware/setup.sh
 
 ./ovirt/setup.sh
 


### PR DESCRIPTION
The VMware setup tried to run before the forklift namespace was created.